### PR TITLE
fix: wrong export of the library

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -46,3 +46,6 @@ class SobjectizerConan(ConanFile):
         self.copy("*.dylib", dst="lib", keep_path=False)
         self.copy("*.a", dst="lib", keep_path=False)
         self.copy("license*", src=self.source_subfolder, dst="licenses",  ignore_case=True, keep_path=False)
+
+    def package_info(self):
+        self.cpp_info.libs = tools.collect_libs(self)


### PR DESCRIPTION
Hi! I've tried here to fix https://github.com/Stiffstream/sobjectizer-conan/issues/1

Local tests show that it works.

I am not sure is it valid fix or not (I am not a Conan expert at all :)

I can recommend you look into:
* https://docs.conan.io/en/latest/reference/conanfile/attributes.html
* modern conan recipes in `conan-center-index`: https://github.com/conan-io/conan-center-index/
* push your recipe into `conan-center-index`